### PR TITLE
Fix info print error

### DIFF
--- a/synckeys.py
+++ b/synckeys.py
@@ -90,7 +90,7 @@ def print_device_info(device_config, device_mac):
 
     # Get paired device name
     device_name = device_config['General']['Name']
-    device_alias = device_config['General']['Alias']
+    device_alias = device_config['General'].get('Alias', device_name)
     print(f'\n  {device_mac} ({device_name} / {device_alias})')
 
 


### PR DESCRIPTION
There was no **alias** set for my bluetooth device on Windows so the script threw an error on launch.

Now it uses `device_name` for `device_alias` in case it isn't available instead of throwing an exception.
I checked and it's the only place where the alias is used.